### PR TITLE
Add shop data for vendor selling support

### DIFF
--- a/Overrides/field_hospital_shop_data.Group.csv
+++ b/Overrides/field_hospital_shop_data.Group.csv
@@ -1,0 +1,6 @@
+element_start,field_hospital,ShopData
+m_canSell,True,
+m_acceptedCategories,combat,inn,stagecoach,trinket,trophy,
+m_goldCostId,gold_sell_cost,
+m_baublesCostId,valley_baubles_sell_cost,
+element_end

--- a/Overrides/field_hospital_shop_data.Group.csv.meta
+++ b/Overrides/field_hospital_shop_data.Group.csv.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a525a1463da14fdd8e484a118d48f575
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Overrides/hoarder_shop_data.Group.csv
+++ b/Overrides/hoarder_shop_data.Group.csv
@@ -1,0 +1,6 @@
+element_start,hoarder,ShopData
+m_canSell,True,
+m_acceptedCategories,combat,inn,stagecoach,trinket,trophy,
+m_goldCostId,gold_sell_cost,
+m_baublesCostId,valley_baubles_sell_cost,
+element_end

--- a/Overrides/hoarder_shop_data.Group.csv.meta
+++ b/Overrides/hoarder_shop_data.Group.csv.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 54b24d8855574a52a22ef003b6f3b168
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Overrides/inn_provisioner_shop_data.Group.csv
+++ b/Overrides/inn_provisioner_shop_data.Group.csv
@@ -1,0 +1,6 @@
+element_start,inn_provisioner,ShopData
+m_canSell,True,
+m_acceptedCategories,combat,inn,stagecoach,trinket,trophy,
+m_goldCostId,gold_sell_cost,
+m_baublesCostId,valley_baubles_sell_cost,
+element_end

--- a/Overrides/inn_provisioner_shop_data.Group.csv.meta
+++ b/Overrides/inn_provisioner_shop_data.Group.csv.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 71eb080e7417490d8f4214b30e6c8cb6
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- allow selling items at the inn provisioner
- allow selling items at the field hospital
- allow selling items at the hoarder

## Testing
- `python -m dd2tools build` *(fails: No module named dd2tools)*

------
https://chatgpt.com/codex/tasks/task_e_689f7a3cd720832e8ea6fba23b53910b