### PR TITLE
Update sell instructions in item localization

### DIFF
--- a/Localization/dlc_dul_cru/items_dlc1.txt
+++ b/Localization/dlc_dul_cru/items_dlc1.txt
@@ -1,4 +1,6 @@
 #Quest Items
+item_discard=[Shift-Click to sell]
+item_sell_value=[Shift-Click to sell for {0} Each]
 item_name_quest_trophy_crusader_helmet_a=Battered Helm
 item_quote_quest_trophy_crusader_helmet_a=<i>A helm of the Crusaders.\n\n\nTheir legions lost, their exploits legend.\n\n\nConfront the scattered dregs of the invading army,\n\n\nand purge them from our lands.</i>\n\n\n<color=#{item_typeline}>Must be equipped to progress The Lost Crusade</color>
 item_name_quest_tattered_banner=Tattered Banner

--- a/Localization/dlc_dul_cru/items_dlc1.txt.meta
+++ b/Localization/dlc_dul_cru/items_dlc1.txt.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f3ae060197cb94a40a081f00f223c42b
+guid: 4c46bade4bea4d8e9b3c624cc0249876
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/Localization/items.txt
+++ b/Localization/items.txt
@@ -1,6 +1,6 @@
 ﻿item_buy_value=[Buy Value: {0} Each]
-item_discard=[Shift-Click to discard]
-item_sell_value=[Sell Value: {0} Each]
+item_discard=[Shift-Click to sell]
+item_sell_value=[Shift-Click to sell for {0} Each]
 item_type_pet=Pet
 item_subtype_pet=Pet
 item_type_food=Provisions

--- a/Localization/items.txt.meta
+++ b/Localization/items.txt.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 78a77f93d92deeb4683a136f4800f5ac
+guid: 0a29c47e678449319635b2fe58953b20
 TextScriptImporter:
   externalObjects: {}
   userData: 


### PR DESCRIPTION
## Summary
- update `item_discard` and `item_sell_value` text to instruct "Shift-Click to sell"
- add same sell instructions to DLC localization
- regenerate `.meta` files for changed localization assets

## Testing
- `rg "item_discard" -n Localization`
- `python - <<'PY'
import pathlib
for f in ['Localization/items.txt','Localization/dlc_dul_cru/items_dlc1.txt','Localization/items.txt.meta','Localization/dlc_dul_cru/items_dlc1.txt.meta']:
    data=pathlib.Path(f).read_bytes()
    try:
        data.decode('utf-8')
        print(f, 'utf-8')
    except UnicodeDecodeError:
        print(f, 'decode error')
PY`


------
https://chatgpt.com/codex/tasks/task_e_689f7a3f7744832e96b37ca32e80b7ca